### PR TITLE
박스명 문제 수정

### DIFF
--- a/berry_fix/payload/include/pokemon.h
+++ b/berry_fix/payload/include/pokemon.h
@@ -147,7 +147,7 @@ struct PokemonStorage
 {
     /*0x0000*/ u8 currentBox;
     /*0x0004*/ struct BoxPokemon boxes[14][30];
-    /*0x8344*/ u8 boxNames[14][9];
+    /*0x8344*/ u8 boxNames[14][16 + 1];
     /*0x83c2*/ u8 wallpaper[14];
 };
 

--- a/include/global.h
+++ b/include/global.h
@@ -468,6 +468,7 @@ struct SaveBlock2
              u16 optionsBattleStyle:1; // OPTIONS_BATTLE_STYLE_[SHIFT/SET]
              u16 optionsBattleSceneOff:1; // whether battle animations are disabled
              u16 regionMapZoom:1; // whether the map is zoomed in
+             u16 useNewBoxName:1;
     /*0x18*/ struct Pokedex pokedex;
     /*0x90*/ u8 filler_90[0x8];
     /*0x98*/ struct Time localTimeOffset;

--- a/include/pokemon_storage_system.h
+++ b/include/pokemon_storage_system.h
@@ -19,7 +19,7 @@ struct PokemonStorage
 {
     /*0x0000*/ u8 currentBox;
     /*0x0001*/ struct BoxPokemon boxes[TOTAL_BOXES_COUNT][IN_BOX_COUNT];
-    /*0x8344*/ u8 boxNames[TOTAL_BOXES_COUNT][9];
+    /*0x8344*/ u8 boxNames[TOTAL_BOXES_COUNT][16 + 1];
     /*0x83C2*/ u8 boxWallpapers[TOTAL_BOXES_COUNT];
 };
 

--- a/src/menu_specialized.c
+++ b/src/menu_specialized.c
@@ -994,9 +994,9 @@ void GetConditionMenuMonNameAndLocString(u8 *locationDst, u8 *nameDst, u16 boxId
         locationDst[3] = TEXT_COLOR_TRANSPARENT;
         locationDst[4] = TEXT_COLOR_LIGHT_BLUE;
         if (box == TOTAL_BOXES_COUNT) // Party mon.
-            BufferConditionMenuSpacedStringN(&locationDst[5], gText_InParty, 8);
+            BufferConditionMenuSpacedStringN(&locationDst[5], gText_InParty, 16);
         else
-            BufferConditionMenuSpacedStringN(&locationDst[5], GetBoxNamePtr(box), 8);
+            BufferConditionMenuSpacedStringN(&locationDst[5], GetBoxNamePtr(box), 16);
     }
     else
     {

--- a/src/naming_screen.c
+++ b/src/naming_screen.c
@@ -507,6 +507,26 @@ static u8 *NamingScreen_StringCopyMultibyte(u8 *dest, const u8 *src)
     return dest;
 }
 
+static u8 *NamingScreen_StringCopy(u8 *dest, const u8 *src)
+{
+    while (*src != EOS)
+    {
+        if (*src == 0)
+        {
+            *(dest++) = *(++src);
+            src++;
+        }
+        else
+        {
+            *dest++ = *src++;
+            *dest++ = *src++;
+        }
+    }
+
+    *dest = EOS;
+    return dest;
+}
+
 static void NamingScreen_Init(void)
 {
     sNamingScreen->state = STATE_FADE_IN;
@@ -2376,31 +2396,15 @@ static void BufferCharacter(u8 ch)
 
 static void SaveInputText(void)
 {
-    u8 i, j;
+    u8 i;
 
-    for (i = 0, j = 0; sNamingScreen->textBuffer[i] != EOS; i += 2)
+    NamingScreen_StringCopy(sNamingScreen->destBuffer, sNamingScreen->textBuffer);
+
+    i = StringLength(sNamingScreen->destBuffer);
+    if (i == 0)
     {
-        if (sNamingScreen->textBuffer[i] == 0)
-        {
-            sNamingScreen->destBuffer[j] = sNamingScreen->textBuffer[i + 1];
-            j++;
-        } else
-        {
-            sNamingScreen->destBuffer[j++] = sNamingScreen->textBuffer[i];
-            sNamingScreen->destBuffer[j++] = sNamingScreen->textBuffer[i + 1];
-        }
+        NamingScreen_StringCopy(sNamingScreen->destBuffer, sNamingScreen->backupBuffer);
     }
-
-    sNamingScreen->destBuffer[j] = EOS;
-
-    for (i = 0; sNamingScreen->destBuffer[i] != EOS; i++)
-    {
-        if (sNamingScreen->destBuffer[i] != EOS)
-            j++;
-    }
-
-    if (j == 0)
-        StringCopy(sNamingScreen->destBuffer, sNamingScreen->backupBuffer);
 }
 
 static void LoadGfx(void)

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1688,21 +1688,29 @@ static void sub_8086204(void)
 static void MigrateNewBoxName(void)
 {
     struct PokemonStorage tempPokemonStorage;
-    u8 *ptr, *namePtr;
+    u8 *ptr, *tempPtr;
     u8 i;
 
     if (gSaveBlock2Ptr->useNewBoxName == FALSE)
     {
         ptr = (u8 *)gPokemonStoragePtr->boxNames[0];
-
         for (i = 0; i < 14; i++)
         {
-            namePtr = ptr + (i * 9);
-            StringCopy(tempPokemonStorage.boxNames[i], namePtr);
+            tempPtr = ptr + (i * 9);
+            StringCopy(tempPokemonStorage.boxNames[i], tempPtr);
         }
 
         for (i = 0; i < 14; i++)
+        {
+            tempPtr = ptr + (9 * 14) + i;
+            tempPokemonStorage.boxWallpapers[i] = *tempPtr;
+        }
+
+        for (i = 0; i < 14; i++)
+        {
             StringCopy(gPokemonStoragePtr->boxNames[i], tempPokemonStorage.boxNames[i]);
+            gPokemonStoragePtr->boxWallpapers[i] = tempPokemonStorage.boxWallpapers[i];
+        }
 
         gSaveBlock2Ptr->useNewBoxName = TRUE;
     }

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -37,6 +37,8 @@
 #include "mirage_tower.h"
 #include "money.h"
 #include "new_game.h"
+#include "pokemon_storage_system.h"
+#include "string_util.h"
 #include "palette.h"
 #include "play_time.h"
 #include "random.h"
@@ -1683,10 +1685,34 @@ static void sub_8086204(void)
     FieldCB_WarpExitFadeFromBlack();
 }
 
+static void MigrateNewBoxName(void)
+{
+    struct PokemonStorage tempPokemonStorage;
+    u8 *ptr, *namePtr;
+    u8 i;
+
+    if (gSaveBlock2Ptr->useNewBoxName == FALSE)
+    {
+        ptr = (u8 *)gPokemonStoragePtr->boxNames[0];
+
+        for (i = 0; i < 14; i++)
+        {
+            namePtr = ptr + (i * 9);
+            StringCopy(tempPokemonStorage.boxNames[i], namePtr);
+        }
+
+        for (i = 0; i < 14; i++)
+            StringCopy(gPokemonStoragePtr->boxNames[i], tempPokemonStorage.boxNames[i]);
+
+        gSaveBlock2Ptr->useNewBoxName = TRUE;
+    }
+}
+
 void CB2_ContinueSavedGame(void)
 {
     u8 trainerHillMapId;
 
+    MigrateNewBoxName();
     FieldClearVBlankHBlankCallbacks();
     StopMapMusic();
     ResetSafariZoneFlag_();

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -1913,6 +1913,8 @@ void ResetPokemonStorageSystem(void)
 {
     u16 boxId, boxPosition;
 
+    gSaveBlock2Ptr->useNewBoxName = TRUE;
+
     SetCurrentBox(0);
     for (boxId = 0; boxId < TOTAL_BOXES_COUNT; boxId++)
     {

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -5520,7 +5520,7 @@ static void sub_80CCB50(u8 boxId)
     sPSSData->field_71E = 0x10e + 16 * tagIndex;
     sPSSData->field_738 |= 0x10000 << tagIndex;
 
-    StringCopyPadded(sPSSData->field_21B8, GetBoxNamePtr(boxId), 0, 8);
+    StringCopyPadded(sPSSData->field_21B8, GetBoxNamePtr(boxId), 0, 16);
     DrawTextWindowAndBufferTiles(sPSSData->field_21B8, sPSSData->field_2F8, 0, 0, 2);
     LoadSpriteSheet(&spriteSheet);
     r6 = sub_80CD00C(GetBoxNamePtr(boxId));
@@ -5556,7 +5556,7 @@ static void sub_80CCCFC(u8 boxId, s8 direction)
         template.paletteTag = TAG_PAL_DAC9;
     }
 
-    StringCopyPadded(sPSSData->field_21B8, GetBoxNamePtr(boxId), 0, 8);
+    StringCopyPadded(sPSSData->field_21B8, GetBoxNamePtr(boxId), 0, 16);
     DrawTextWindowAndBufferTiles(sPSSData->field_21B8, sPSSData->field_2F8, 0, 0, 2);
     LoadSpriteSheet(&spriteSheet);
     LoadPalette(gUnknown_08577574[GetBoxWallpaper(boxId)], r8, 4);

--- a/src/pokenav_conditions_1.c
+++ b/src/pokenav_conditions_1.c
@@ -433,9 +433,9 @@ void CopyMonNameGenderLocation(s16 id, u8 arg1)
         structPtr->searchLocBuffer[arg1][3] = TEXT_COLOR_TRANSPARENT;
         structPtr->searchLocBuffer[arg1][4] = TEXT_COLOR_LIGHT_BLUE;
         if (boxId == TOTAL_BOXES_COUNT)
-            CopyStringLeftAlignedToConditionData(&structPtr->searchLocBuffer[arg1][5], gText_InParty, 8);
+            CopyStringLeftAlignedToConditionData(&structPtr->searchLocBuffer[arg1][5], gText_InParty, 16);
         else
-            CopyStringLeftAlignedToConditionData(&structPtr->searchLocBuffer[arg1][5], GetBoxNamePtr(boxId), 8);
+            CopyStringLeftAlignedToConditionData(&structPtr->searchLocBuffer[arg1][5], GetBoxNamePtr(boxId), 16);
     }
     else
     {


### PR DESCRIPTION
# 문제
* #34 : 박스 이름을 길게 지을 경우 에러 발생

# 원인
* 이름 짓기 시스템을 한글입력 구현으로 바이트수가 2배 확장하면서, 박스명 데이터에 들어갈 공간도 확장을 해야하는데 해당 부분이 누락되었습니다.
* 간단히 수정이 가능하지만 기존 플레이하던 세이브가 재대로 호환하지 않는 문제가 생길 수 있습니다.